### PR TITLE
Allow reuse of linter object

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -3,7 +3,8 @@
 var helper = require('./linter-utils'),
     parser = require('./parser'),
     loadRules = require('./rulefile-loader').load,
-    logger = require('./logger');
+    logger = require('./logger'),
+    _ = require('lodash');
 
 //TODO move to utils
 function printObject(obj) {
@@ -61,12 +62,6 @@ function validateCommand(command, context, result) {
 function Linter(ruleFilePath) {
     if (!ruleFilePath) logger.info("No rule file provided, using default rules");
     this.rules = loadRules(ruleFilePath);
-    this.context = {
-        rules: this.rules,
-        validInstructionsRegex: helper.createValidCommandRegex(this.rules.general.valid_instructions),
-        requiredInstructions: helper.createReqInstructionHash(this.rules),
-        requiredNameVals: helper.createRequiredNameValDict(this.rules)
-    };
     helper.initLineRulesRegexes(this.rules);
 }
 
@@ -76,11 +71,25 @@ function Linter(ruleFilePath) {
  */
 Linter.prototype.getProfile = function () {
     return this.rules.profile;
-};
+}
+
+
+Linter.prototype.initContext = function(){
+    var ruleCopy = _.cloneDeep(this.rules);
+    this.context = {
+        rules: ruleCopy,
+        validInstructionsRegex: helper.createValidCommandRegex(ruleCopy.general.valid_instructions),
+        requiredInstructions: helper.createReqInstructionHash(ruleCopy),
+        requiredNameVals: helper.createRequiredNameValDict(ruleCopy)
+    };
+}
 
 /**
  * Validate  dockerfile contents string and returns the array of analysis
  * results.
+ *
+ * The validate can be called safely multiple times with the same instance of
+ * of the Linter
  *
  * @param contents {String}  The dockerfile file content.
  * @returns        {Array}
@@ -92,6 +101,7 @@ Linter.prototype.validate = function (contents) {
         }]);
     }
     var result = helper.newResult();
+    this.initContext(); //start with a clean context to allow multiple calls.
     var options = {includeComments: false};
     var commands = parser.parse(contents, options);
     // @see  parser.parse for format of commands


### PR DESCRIPTION
This change allows a Linter instance with a given rule set to be reused multiple times without side effects.
This is useful for long running applications.