### PR TITLE
Added new function - SHELL

### DIFF
--- a/config/base_rules.yaml
+++ b/config/base_rules.yaml
@@ -20,6 +20,7 @@
       - "WORKDIR"
       - "ONBUILD"
       - "ARG"
+      - "SHELL"
       - "STOPSIGNAL"
     ignore_regex: /^#/
     multiline_regex: /\\$/
@@ -34,6 +35,9 @@
       paramSyntaxRegex: /.+/
       rules: []
     RUN:
+      paramSyntaxRegex: /.+/
+      rules: []
+    SHELL:
       paramSyntaxRegex: /.+/
       rules: []
     CMD:


### PR DESCRIPTION
Please merge this as the ruleset in itself cannot approve changes to the allowed instructions. Shell is a valid docker instruction.
