### PR TITLE
accept dot in FROM version and dash in USER

### DIFF
--- a/config/default_rules.yaml
+++ b/config/default_rules.yaml
@@ -73,7 +73,7 @@
                - "_recommended_labels_for_your_project"
 
     FROM: 
-      paramSyntaxRegex: /^[\w./-]+(:[\w.]+)?(-[\w]+)?$/
+      paramSyntaxRegex: /^[\w./-]+(:[\w.]+)?(-[\w.]+)?$/
       rules: 
         - 
           label: "is_latest_tag"
@@ -203,7 +203,7 @@
       paramSyntaxRegex: /.+/
       rules: []
     USER: 
-      paramSyntaxRegex: /^[a-z0-9_][a-z0-9_]{0,40}$/
+      paramSyntaxRegex: /^[a-z0-9_][a-z0-9_-]{0,40}$/
       rules: []
     WORKDIR: 
       paramSyntaxRegex: /^~?[\w\d-\/.{}$\/:]+[\s]*$/


### PR DESCRIPTION
I noticed the actual regexp seemed too restrictive.

For example, I belive this should be valid (currently refused because of the dot in the version):
```
FROM scaleway/docker:amd64-1.10
```

And this one is definitively valid (Ubuntu default, currently refused because of the dash):
```
USER www-data
```