### PR TITLE
Adding Docker 1.12 valid instructions

### DIFF
--- a/config/base_rules.yaml
+++ b/config/base_rules.yaml
@@ -32,10 +32,16 @@
     FROM:
       paramSyntaxRegex: /.+/
       rules: []
+    HEALTHCHECK:
+      paramSyntaxRegex: /.+/
+      rules: []
     MAINTAINER:
       paramSyntaxRegex: /.+/
       rules: []
     RUN:
+      paramSyntaxRegex: /.+/
+      rules: []
+    SHELL:
       paramSyntaxRegex: /.+/
       rules: []
     CMD:

--- a/config/base_rules.yaml
+++ b/config/base_rules.yaml
@@ -21,6 +21,8 @@
       - "ONBUILD"
       - "ARG"
       - "STOPSIGNAL"
+      - "HEALTHCHECK"
+      - "SHELL"
     ignore_regex: /^#/
     multiline_regex: /\\$/
   line_rules:

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -132,7 +132,7 @@ function parseHealthcheck(cmd) {
         noneDirectiveIndex = words.indexOf("NONE");
 
     if (cmdDirectiveIndex === -1 && noneDirectiveIndex === -1) {
-        cmd.error = 'A HEALTCHECK instruction must specify either NONE, or a valid CMD and options';
+        cmd.error = 'A HEALTHCHECK instruction must specify either NONE, or a valid CMD and options';
         return false;
     } else if (cmdDirectiveIndex !== -1) {
         // Reject a CMD directive that doesn't preceed an actual command.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -124,6 +124,55 @@ function parseWords(rest) {
     return words;
 }
 
+// Parse the HEALTHCHECK command.
+// https://docs.docker.com/engine/reference/builder/#/healthcheck
+function parseHealthcheck(cmd) {
+    var words = parseWords(cmd.rest),
+        cmdDirectiveIndex = words.indexOf("CMD"),        
+        noneDirectiveIndex = words.indexOf("NONE");
+
+    if (cmdDirectiveIndex === -1 && noneDirectiveIndex === -1) {
+        cmd.error = 'A HEALTCHECK instruction must specify either NONE, or a valid CMD and options';
+        return false;
+    } else if (cmdDirectiveIndex !== -1) {
+        // Reject a CMD directive that doesn't preceed an actual command.
+        if (cmdDirectiveIndex === words.length - 1) {
+            cmd.error = 'A CMD directive must specify a command for the healthcheck to run';
+            return false;
+        }
+        
+        cmd.args = { command: words.slice(cmdDirectiveIndex + 1).join(" ") };
+
+        if (cmdDirectiveIndex > 0) {
+            // There are options specified, so let's verify they're valid.
+            var cmdDirectiveOptions = words.slice(0, cmdDirectiveIndex),
+                validCmdOptions = ["interval", "retries", "timeout"];
+
+            for (var i = 0; i < cmdDirectiveOptions.length; i++) {
+                var match = /--(\w+)=(\d+)/.exec(cmdDirectiveOptions[i]);
+                if (!match) {
+                    cmd.error = '"' + cmdDirectiveOptions[i] + '" isn\'t a syntactically valid CMD option';
+                    return false;
+                } else if (validCmdOptions.indexOf(match[1]) === -1) {
+                    cmd.error = '"' + match[1] + '" isn\'t a valid CMD option';
+                    return false;
+                }
+
+                cmd.args[match[1]] = match[2];
+            }
+        }
+    } else if (noneDirectiveIndex !== -1) {
+        if (words.length > 1) {
+            cmd.error = 'The NONE directive doesn\'t support additional options';
+            return false;
+        }
+
+        cmd.args = { isNone: true };
+    }
+
+    return true;
+}
+
 // Parse environment like statements. Note that this does *not* handle
 // variable interpolation, which will be handled in the evaluator.
 function parseNameVal(cmd) {
@@ -271,6 +320,7 @@ var commandParsers = {
     'ENV': parseEnv,
     'EXPOSE': parseStringsWhitespaceDelimited,
     'FROM': parseString,
+    'HEALTHCHECK': parseHealthcheck,
     'LABEL': parseLabel,
     'MAINTAINER': parseString,
     'ONBUILD': parseSubCommand,

--- a/test/data/rules/loader_test_combine_main.expected.json
+++ b/test/data/rules/loader_test_combine_main.expected.json
@@ -25,7 +25,9 @@
       "WORKDIR",
       "ONBUILD",
       "ARG",
-      "STOPSIGNAL"
+      "STOPSIGNAL",
+      "HEALTHCHECK",
+      "SHELL"
     ],
     "ignore_regex": "/^#/",
     "multiline_regex": "/\\\\$/"

--- a/test/data/rules/loader_test_combine_main.expected.json
+++ b/test/data/rules/loader_test_combine_main.expected.json
@@ -64,11 +64,19 @@
         }
       ]
     },
+    "HEALTHCHECK": {
+      "paramSyntaxRegex": "/.+/",
+      "rules": []
+    },
     "MAINTAINER": {
       "paramSyntaxRegex": "/.+/",
       "rules": []
     },
     "RUN": {
+      "paramSyntaxRegex": "/.+/",
+      "rules": []
+    },
+    "SHELL": {
       "paramSyntaxRegex": "/.+/",
       "rules": []
     },

--- a/test/data/rules/loader_test_include_chain.expected.json
+++ b/test/data/rules/loader_test_include_chain.expected.json
@@ -75,6 +75,10 @@
         }
       ]
     },
+    "HEALTHCHECK": {
+      "paramSyntaxRegex": "/.+/",
+      "rules": []
+    },
     "MAINTAINER": {
       "paramSyntaxRegex": "/.+/",
       "rules": []
@@ -99,6 +103,10 @@
           "reference_url": "https://github.com/jpetazzo/nsenter"
         }
       ]
+    },
+    "SHELL": {
+      "paramSyntaxRegex": "/.+/",
+      "rules": []
     },
     "CMD": {
       "paramSyntaxRegex": "/.+/",

--- a/test/data/rules/loader_test_include_chain.expected.json
+++ b/test/data/rules/loader_test_include_chain.expected.json
@@ -25,7 +25,9 @@
       "WORKDIR",
       "ONBUILD",
       "ARG",
-      "STOPSIGNAL"
+      "STOPSIGNAL",
+      "HEALTHCHECK",
+      "SHELL"
     ],
     "ignore_regex": "/^#/",
     "multiline_regex": "/\\\\$/"


### PR DESCRIPTION
This updates the valid instructions list in the base rules in order to support the `HEALTHCHECK` and `SHELL` commands that were added in Docker 1.12. Additionally, it also adds a custom parser for the `HEALTHCHECK` command, in order for the linter to detect whether it's syntactically valid, and whether any specified option names are allowed.

The following demonstrates the use of this change within the VS Code extension for Docker (which uses `dockerfile_lint` to generate the warnings);

<img width="736" alt="screen shot 2016-12-02 at 3 19 25 pm" src="https://cloud.githubusercontent.com/assets/116461/20853718/c43da948-b8a2-11e6-8800-69f042f458fc.png">