### PR TITLE
Remove custom registry rule from FROM instruction

### DIFF
--- a/config/default_rules.yaml
+++ b/config/default_rules.yaml
@@ -92,14 +92,6 @@
           reference_url: 
             - "https://docs.docker.com/reference/builder/"
             - "#from"
-          label: "specified_registry"
-          regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
-          level: "info"
-          message: "using a specified registry in the FROM line"
-          description: "using a specified registry may supply invalid or unexpected base images"
-          reference_url:
-            - "https://docs.docker.com/reference/builder/"
-            - "#entrypoint"
     MAINTAINER: 
       paramSyntaxRegex: /.+/
       rules: []


### PR DESCRIPTION
This rule triggers a false negative when an image name uses a custom registry with either a sub-domain or a port. For example, the following image names are considered valid: `node`, `node:6.9.1`, and `quay.io/node`. However, if you try `foo.quay.io/node` or `quay.io:80/node`, this rule triggers a lint error.

Additionally, since using a custom registry is completely valid, I'm not sure whether this rule is even needed, since the regex for the `FROM` instruction should already be doing the proper syntax linting.