### PR TITLE
regex must not be quoted,   some text fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ ADD . .
 RUN npm install && \
     ln -s /opt/dockerfile_lint/bin/dockerfile_lint /usr/bin/dockerfile_lint
 
+RUN mkdir /sample_rules  && \
+    cp sample_rules/basic_rules_atomic.yaml  sample_rules/basic_rules.yaml  sample_rules/label_rules.yaml  \
+       sample_rules/openshift.yaml  sample_rules/osbs.yaml  sample_rules/recommended_label_rules.yaml \
+       sample_rules/default_rules.yaml /sample_rules
+
+
 WORKDIR /root/
 LABEL RUN docker run -it --rm --privileged -v `pwd`:/root/ -v /var/run/docker.sock:/var/run/docker.sock --name NAME -e NAME=NAME -e IMAGE=IMAGE IMAGE dockerfile_lint
 

--- a/sample_rules/basic_rules_atomic.yaml
+++ b/sample_rules/basic_rules_atomic.yaml
@@ -24,7 +24,7 @@
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
            Version:
-             valueRegex: "/[\w.${}()"'\\\/~<>\-?\%:]+/"
+             valueRegex: /[\w.${}()"'\\\/~<>\-?\%:]+/
              message: "Label 'Version' is missing or has invalid format"
              level: "warn"
              required: true
@@ -32,7 +32,7 @@
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
            Release:
-             valueRegex: "/[\w.${}()"'\\\/~<>\-?\%:]+/"
+             valueRegex: /[\w.${}()"'\\\/~<>\-?\%:]+/
              message: "Label 'Release' is missing or has invalid format"
              level: "warn"
              required: true
@@ -93,7 +93,7 @@
             - "https://docs.docker.com/reference/builder/"
             - "#from"
           label: "specified_registry"
-          regex: "/[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/"
+          regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
           level: "warn"
           message: "using a specified registry in the FROM line"
           description: "using a specified registry may supply invalid or unexpected base images"

--- a/sample_rules/modules.yaml
+++ b/sample_rules/modules.yaml
@@ -1,65 +1,70 @@
 ---
   profile:
-    name: "Osbs"
-    description: "Osbs Profile. Checks basic syntax and checks for required BZComponents etc."
+    name: "modules"
+    description: "module Profile for the Modularity project. Checks basic syntax"
     includes:
-      #- recommended_label_rules.yaml
+     # - recommended_label_rules.yaml
   line_rules:
     LABEL:
        paramSyntaxRegex: /.+/
        # Use defined_label_rules to defined a set of labels for your dockerfile
-       # In this example, the labels "Vendor","Authoritative_Registry","BZComponent"
+       # In this example, the labels "Vendor","Authoritative_Registry"
        # have been defined. A label value is 'valid' if matches the regular
        # expression 'valueRegex', otherwise an warn is logged with the string "message"
        # at level 'level'.  'reference_url' provides a web link where the user can
        # get more information about the rule.
        #
        defined_namevals:
-           BZComponent:
-             valueRegex: /([\w.\/\\:-]+)/ 
-             message: "Label 'BZComponent' is missing or has invalid format"
-             level: "error"
+#           com.redhat.component:
+#             valueRegex: /([\w]+).+/
+#             message: "Label 'com.redhat.component' is missing or has invalid format"
+#             level: "warn"
+#             required: false
+#             reference_url:
+#               - "https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md"
+           Org.fedoraproject.component:
+             valueRegex: /([\w]+).+/
+             message: "Label 'com.redhat.component' is missing or has invalid format"
+             level: "info"
              required: true
              reference_url:
-               - "http://docs.projectatomic.io/container-best-practices/#"
-               - "_recommended_labels_for_your_project"
-           Name:
-             valueRegex: /([\w]+)./
-             message: "Label 'Name' is missing or has invalid format"
-             level: "error"
+               - "https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md"
+           Authoritative-source-url:
+             valueRegex: /([\w]+).+/
+             message: "Label 'authoritative-source-url' is missing or has invalid format"
+             level: "info"
              required: true
+             reference_url:
+               - "https://github.com/projectatomic/ContainerApplicationGenericLabels/blob/master/vendor/redhat/labels.md"
+           Architecture:
+             valueRegex: /[\w]*[6,8][4,6]|[.]*86[.]*64|[.]*ppc64|[.]*s390x|[.]*aarch64|[.]*armv7hl/
+             message: "Label 'Architecture' is missing or has invalid format: x86, i386, x86_64, ppc64, ppc64le, s390x, armv7hl"
+             level: "info"
+             required: false
              reference_url:
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
            Version:
-             valueRegex: /[\w.${}()"'\\\/~<>\-?\%:]+/
+             valueRegex:  /[\w.${}()"'\\\/~<>\-?\%:]+/
              message: "Label 'Version' is missing or has invalid format"
-             level: "error"
+             level: "warn"
              required: true
              reference_url:
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
            Release:
-             valueRegex: /[\w.${}()"'\\\/~<>\-?\%:]+/
+             valueRegex:  /[\w.${}()"'\\\/~<>\-?\%:]+/
              message: "Label 'Release' is missing or has invalid format"
-             level: "error"
+             level: "warn"
              required: true
              reference_url:
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
-           Architecture:
-             valueRegex: /[\w]*[6,8][4,6]|[.]*86[.]*64/
-             message: "Label 'Architecture' is missing or has invalid format: x86, i386, x86_64"
-             level: "info"
-             required: false
-             reference_url:
-               - "http://docs.projectatomic.io/container-best-practices/#"
-               - "_recommended_labels_for_your_project"
-           Url:
+           Vendor:
              valueRegex: /([\w]+).+/
-             message: "Label 'Url' is missing or has invalid format"
-             level: "info"
-             required: false
+             message: "Label 'Vendor' is missing or has invalid format"
+             level: "warn"
+             required: true
              reference_url:
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
@@ -71,26 +76,31 @@
              reference_url:
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
+
     FROM: 
-      paramSyntaxRegex: /^[\w./-]+(:[\w.]+)?(-[\w]+)?$/
+      paramSyntaxRegex: /^[\w./-]+(:[\w.]+)?(-[\w.]+)?$/
       rules: 
         - 
+          # Matches 'FROM fedora:latest'
           label: "is_latest_tag"
-          regex: /latest/
+          regex: /:latest/
           level: "error"
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url: 
             - "https://docs.docker.com/reference/builder/"
             - "#from"
+        - 
+          # Matches 'FROM fedora:'
           label: "no_tag"
-          regex: /^[:]/
+          regex: /[.[^:]+$/
           level: "warn"
           message: "No tag is used"
-          description: "lorem ipsum tar"
+          description: "specifying no tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url: 
             - "https://docs.docker.com/reference/builder/"
             - "#from"
+        - 
           label: "specified_registry"
           regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
           level: "info"
@@ -99,6 +109,14 @@
           reference_url:
             - "https://docs.docker.com/reference/builder/"
             - "#entrypoint"
+        -
+          label: "not_from_fedora"
+          regex: /fedora/
+          inverse_rule: true
+          level: "error"
+          message: "Base Image is not from Fedora"
+          description: "Base Image must be from Fedora"
+          reference_url:
     RUN: 
       paramSyntaxRegex: /.+/
       rules: 
@@ -130,33 +148,6 @@
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
-          label: "no_rvm_cleanup_all"
-          regex: /rvm install(?!.+cleanup all)/g
-          level: "warn"
-          message: "rvm cleanup is not used"
-          description: "the rvm cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
-            - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads"
-        -
-          label: "no_gem_clean_all"
-          regex: /gem install(?!.+cleanup|.+\rvm cleanup all)/g
-          level: "warn"
-          message: "gem cleanup all is not used"
-          description: "the gem cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
-            - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
-        -
-          label: "no_apt-get_clean"
-          regex: /apt-get install(?!.+clean)/g
-          level: "warn"
-          message: "apt-get clean is not used"
-          description: "the apt-get cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
-            - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
-        -
           label: "privileged_run_container"
           regex: /privileged/
           level: "warn"
@@ -166,13 +157,6 @@
             - "http://docs.docker.com/engine/reference/run/#"
             - "runtime-privilege-and-linux-capabilities"
         -
-          label: "installing_ssh"
-          regex: /openssh-server/
-          level: "warn"
-          message: "installing SSH in a container is not recommended"
-          description: "Do you really need SSH in this image?"
-          reference_url: "https://github.com/jpetazzo/nsenter"	
-        - 
           label: "no_ampersand_usage"
           regex: / ; /
           level: "warn"
@@ -181,15 +165,6 @@
           reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "#_using_semi_colons_vs_double_ampersands"
-        - 
-          label: "no_epel"
-          regex: /epel/
-          level: "warn"
-          message: "Using epel is not recommended for the osbs profile."
-          description: "Using epel RPMS is not recommended for the osbs profile."
-          reference_url: 
-            - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads"
     EXPOSE: 
       paramSyntaxRegex: /^[\d-\s\w/\\]+$/
       rules: []
@@ -216,8 +191,11 @@
     ONBUILD: 
       paramSyntaxRegex: /.+/
       rules: []
+    MAINTAINER:
+      paramSyntaxRegex: /.+/
+      rules: []
   required_instructions: 
-    - 
+    -
       instruction: "EXPOSE"
       count: 1
       level: "info"
@@ -226,15 +204,6 @@
       reference_url: 
         - "https://docs.docker.com/reference/builder/"
         - "#expose"
-    - 
-      instruction: "ENTRYPOINT"
-      count: 1
-      level: "info"
-      message: "There is no 'ENTRYPOINT' instruction"
-      description: "None"
-      reference_url: 
-        - "https://docs.docker.com/reference/builder/"
-        - "#entrypoint"
     - 
       instruction: "CMD"
       count: 1
@@ -249,28 +218,10 @@
       count: 1
       level: "warn"
       message: "No 'USER' instruction"
-      description: "The process(es) within the container may run as root and RUN instructions my be run as root"
+      description: "The process(es) within the container may run as root and RUN instructions may be run as root"
       reference_url: 
         - "https://docs.docker.com/reference/builder/"
         - "#user"
-    -
-      instruction: "INSTALL"
-      count: 1
-      level: "warn"
-      message: "No 'INSTALL' instruction"
-      description: "The INSTALL process provides information how to run an atomic install for the container"
-      reference_url:
-        - "http://docs.projectatomic.io/container-best-practices/#"
-        - "_recommended_labels_for_your_project"
-    -
-      instruction: "UNINSTALL"
-      count: 1
-      level: "warn"
-      message: "No 'UNINSTALL' instruction"
-      description: "The UNINSTALL process provides information how to run an atomic uninstall for the container and clean up"
-      reference_url:
-        - "http://docs.projectatomic.io/container-best-practices/#"
-        - "_recommended_labels_for_your_project"
     -
       instruction: "RUN"
       count: 1
@@ -280,3 +231,9 @@
       reference_url:
         - "http://docs.projectatomic.io/container-best-practices/#"
         - "_recommended_labels_for_your_project"
+
+#             message: "MAINTAINER is deprecated, use LABEL instead"
+#             level: "info"
+#             required: true
+#             reference_url: 
+#               - "https://docs.docker.com/engine/reference/builder/#maintainer-deprecated"

--- a/sample_rules/openshift.yaml
+++ b/sample_rules/openshift.yaml
@@ -25,15 +25,15 @@
                - "defining-image-metadata" 
            'io.openshift.wants':
              valueRegex: /([\w]+)./
-             message: "Label 'io.openshift.tags' is missing or has invalid format"
+             message: "Label 'io.openshift.wants' is missing or has invalid format"
              level: "warn"
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
                - "defining-image-metadata" 
-           'io.k8s.description':
+           'io.openshift.description':
              valueRegex: /([\w]+)./
-             message: "Label 'io.openshift.tags' is missing or has invalid format"
+             message: "Label 'io.openshift.description' is missing or has invalid format"
              level: "warn"
              required: true
              reference_url:
@@ -41,7 +41,7 @@
                - "defining-image-metadata" 
            'io.openshift.expose-services':
              valueRegex: /([\w:-]+)./
-             message: "Label 'io.openshift.tags' is missing or has invalid format"
+             message: "Label 'io.openshift.expose-services' is missing or has invalid format"
              level: "warn"
              required: true
              reference_url:
@@ -49,7 +49,7 @@
                - "defining-image-metadata" 
            'io.openshift.non-scalable':
              valueRegex: /([\w]+)./
-             message: "Label 'io.openshift.tags' is missing or has invalid format"
+             message: "Label 'io.openshift.non-scalable' is missing or has invalid format"
              level: "warn"
              required: true
              reference_url:
@@ -57,7 +57,7 @@
                - "defining-image-metadata" 
            'io.openshift.min-memory':
              valueRegex: /([\w]+)./
-             message: "Label 'io.openshift.tags' is missing or has invalid format"
+             message: "Label 'io.openshift.min-memory' is missing or has invalid format"
              level: "warn"
              required: true
              reference_url:
@@ -65,7 +65,7 @@
                - "defining-image-metadata" 
            'io.openshift.min-cpu':
              valueRegex: /([\w]+)./
-             message: "Label 'io.openshift.tags' is missing or has invalid format"
+             message: "Label 'io.openshift.min-cpu' is missing or has invalid format"
              level: "warn"
              required: true
              reference_url:
@@ -92,7 +92,7 @@
             - "https://docs.docker.com/reference/builder/"
             - "#from"
           label: "specified_registry"
-          regex: "/[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/"
+          regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
           level: "warn"
           message: "using a specified registry in the FROM line"
           description: "using a specified registry may supply invalid or unexpected base images"

--- a/sample_rules/openshift.yaml
+++ b/sample_rules/openshift.yaml
@@ -15,6 +15,7 @@
        # get more information about the rule.
        #
        defined_namevals:
+         -
            'io.openshift.tags':
              valueRegex: /([\w]+)./
              message: "Label 'io.openshift.tags' is missing or has invalid format"


### PR DESCRIPTION
This is what you'll get without this patch:
/opt/dockerfile_lint/node_modules/js-yaml/lib/js-yaml/loader.js:164
  throw generateError(state, message);
  ^
YAMLException: JS-YAML: unknown escape sequence at line 95, column 22:
              regex: "/[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+) ... 

That's caused by quotes around one regex