### PR TITLE
fixing docker docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/projectatomic/dockerfile_lint.svg?branch=master)](https://travis-ci.org/projectatomic/dockerfile_lint)
 #dockerfile-lint
 
-A rule based 'linter' for [Dockerfiles](https://docs.docker.com/reference/builder/). The linter rules can be used  to check file syntax as well as arbitrary semantic and best practice attributes determined by the rule file writer.
+A rule based 'linter' for [Dockerfiles](https://docs.docker.com/engine/reference/builder/). The linter rules can be used  to check file syntax as well as arbitrary semantic and best practice attributes determined by the rule file writer.
 The linter can also be used to check LABEL rules against docker images.
 #Quickstart
 
@@ -80,7 +80,7 @@ line_rules:
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line."
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
         - 
           label: "no_tag"
@@ -90,7 +90,7 @@ line_rules:
           message: "No tag is used"
           description: "No tag is used"
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
         - 
           label: "from_not_redhat"

--- a/config/base_rules.yaml
+++ b/config/base_rules.yaml
@@ -3,7 +3,7 @@
     name: "Default"
     description: "Default Profile. Checks basic syntax."
   general:
-    ref_url_base: "https://docs.docker.com/reference/builder/"
+    ref_url_base: "https://docs.docker.com/engine/reference/builder/"
     valid_instructions:
       - "FROM"
       - "MAINTAINER"

--- a/config/default_rules.yaml
+++ b/config/default_rules.yaml
@@ -82,7 +82,7 @@
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "no_tag"
           regex: /^[:]/
@@ -90,7 +90,7 @@
           message: "No tag is used"
           description: "lorem ipsum tar"
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
     MAINTAINER: 
       paramSyntaxRegex: /.+/
@@ -211,7 +211,7 @@
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
     - 
       instruction: "CMD"
@@ -220,5 +220,5 @@
       message: "There is no 'CMD' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"

--- a/lib/linter-utils.js
+++ b/lib/linter-utils.js
@@ -120,7 +120,7 @@ module.exports.addResult = addResult;
 
 
 function addError(result, lineNumber, line, msg, ref_url) {
-    if (!ref_url) ref_url = "https://docs.docker.com/reference/builder/";
+    if (!ref_url) ref_url = "https://docs.docker.com/engine/reference/builder/";
     addResult(result, lineNumber, line, msg, 'error', ref_url);
 }
 module.exports.addError = addError;

--- a/sample_rules/basic_rules.yaml
+++ b/sample_rules/basic_rules.yaml
@@ -82,7 +82,7 @@
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "no_tag"
           regex: /^[:]/
@@ -90,7 +90,7 @@
           message: "No tag is used"
           description: "lorem ipsum tar"
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "specified_registry"
           regex: /[a-zA-Z0-9]+?\.[a-zA-Z0-9-]+(\:|\.)([a-zA-Z0-9.]+|(\d+)?)([/?:].*)?/
@@ -98,7 +98,7 @@
           message: "using a specified registry in the FROM line"
           description: "using a specified registry may supply invalid or unexpected base images"
           reference_url:
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#entrypoint"
     MAINTAINER: 
       paramSyntaxRegex: /.+/
@@ -219,7 +219,7 @@
       message: "Maintainer is not defined"
       description: "The MAINTAINER line is useful for identifying the author in the form of MAINTAINER Joe Smith <joe.smith@example.com>"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#maintainer"
     - 
       instruction: "EXPOSE"
@@ -228,7 +228,7 @@
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
     - 
       instruction: "ENTRYPOINT"
@@ -237,7 +237,7 @@
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
     - 
       instruction: "CMD"
@@ -246,7 +246,7 @@
       message: "There is no 'CMD' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
     - 
       instruction: "USER"
@@ -255,5 +255,5 @@
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#user"

--- a/sample_rules/basic_rules_atomic.yaml
+++ b/sample_rules/basic_rules_atomic.yaml
@@ -82,7 +82,7 @@
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "no_tag"
           regex: /^[:]/
@@ -90,7 +90,7 @@
           message: "No tag is used"
           description: "lorem ipsum tar"
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "specified_registry"
           regex: "/[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/"
@@ -98,7 +98,7 @@
           message: "using a specified registry in the FROM line"
           description: "using a specified registry may supply invalid or unexpected base images"
           reference_url:
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#entrypoint"
     MAINTAINER: 
       paramSyntaxRegex: /.+/
@@ -219,7 +219,7 @@
       message: "Maintainer is not defined"
       description: "The MAINTAINER line is useful for identifying the author in the form of MAINTAINER Joe Smith <joe.smith@example.com>"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#maintainer"
     - 
       instruction: "EXPOSE"
@@ -228,7 +228,7 @@
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
     - 
       instruction: "ENTRYPOINT"
@@ -237,7 +237,7 @@
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
     - 
       instruction: "CMD"
@@ -246,7 +246,7 @@
       message: "There is no 'CMD' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
     - 
       instruction: "USER"
@@ -255,7 +255,7 @@
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#user"
     -
       instruction: "INSTALL"

--- a/sample_rules/label_rules.yaml
+++ b/sample_rules/label_rules.yaml
@@ -9,7 +9,7 @@ line_rules:
         level: error
         message: "ENV 'MYSQL_IP' is has invalid format"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#from"
         required: true
         valueRegex: /^[\d.]+$/
@@ -20,7 +20,7 @@ line_rules:
         level: error
         message: "Label 'Authoritative_Registry' has invalid format"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#from"
         required: true
         valueRegex: /.+/
@@ -28,7 +28,7 @@ line_rules:
         level: error
         message: "Label 'BZComponent' has invalid format"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#from"
         required: recommended
         valueRegex: /^\d+$/
@@ -36,7 +36,7 @@ line_rules:
         level: error
         message: "Label 'Created_TimeStamp' has invalid format"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#from"
         required: recommended
         valueRegex: /.+/
@@ -44,7 +44,7 @@ line_rules:
         level: error
         message: "Label 'Vendor' has invalid format"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#from"
         required: false
         valueRegex: /.+/
@@ -52,7 +52,7 @@ line_rules:
         level: error
         message: "Label 'Vendor ID' is has invalid format"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#from"
         required: true
         valueRegex: /^\d+$/
@@ -61,7 +61,7 @@ line_rules:
       level: error
       name_error_message: "The key of the label has the wrong format"
       reference_url:
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#from"
       valueRegex: /.+/
       value_error_message: "The value of the label has the wrong format"
@@ -74,5 +74,5 @@ required_instructions:
     level: error
     message: "No LABELs are defined"
     reference_url:
-      - "https://docs.docker.com/reference/builder/"
+      - "https://docs.docker.com/engine/reference/builder/"
       - "#label"

--- a/sample_rules/openshift.yaml
+++ b/sample_rules/openshift.yaml
@@ -81,7 +81,7 @@
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "no_tag"
           regex: /^[:]/
@@ -89,7 +89,7 @@
           message: "No tag is used"
           description: "lorem ipsum tar"
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "specified_registry"
           regex: "/[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/"
@@ -97,7 +97,7 @@
           message: "using a specified registry in the FROM line"
           description: "using a specified registry may supply invalid or unexpected base images"
           reference_url:
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#entrypoint"
     RUN: 
       paramSyntaxRegex: /.+/
@@ -215,7 +215,7 @@
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
     - 
       instruction: "ENTRYPOINT"
@@ -224,7 +224,7 @@
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
     - 
       instruction: "CMD"
@@ -233,7 +233,7 @@
       message: "There is no 'CMD' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
     - 
       instruction: "USER"
@@ -242,7 +242,7 @@
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#user"
     -
       instruction: "INSTALL"

--- a/sample_rules/osbs.yaml
+++ b/sample_rules/osbs.yaml
@@ -81,7 +81,7 @@
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "no_tag"
           regex: /^[:]/
@@ -89,7 +89,7 @@
           message: "No tag is used"
           description: "lorem ipsum tar"
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
           label: "specified_registry"
           regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
@@ -97,7 +97,7 @@
           message: "using a specified registry in the FROM line"
           description: "using a specified registry may supply invalid or unexpected base images"
           reference_url:
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#entrypoint"
     RUN: 
       paramSyntaxRegex: /.+/
@@ -224,7 +224,7 @@
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
     - 
       instruction: "ENTRYPOINT"
@@ -233,7 +233,7 @@
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
     - 
       instruction: "CMD"
@@ -242,7 +242,7 @@
       message: "There is no 'CMD' instruction"
       description: "None"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
     - 
       instruction: "USER"
@@ -251,7 +251,7 @@
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#user"
     -
       instruction: "INSTALL"

--- a/sample_rules/recommended_label_rules.yaml
+++ b/sample_rules/recommended_label_rules.yaml
@@ -66,6 +66,6 @@
    #   message: "No LABELs are defined"
    #   description: "Labels are needed because...."
    #   reference_url:
-   #     - "https://docs.docker.com/reference/builder/"
+   #     - "https://docs.docker.com/engine/reference/builder/"
    #     - "#label"
 

--- a/test/data/rules/basic.yaml
+++ b/test/data/rules/basic.yaml
@@ -13,7 +13,7 @@
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line."
           reference_url:
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
         -
           label: "no_tag"
@@ -22,7 +22,7 @@
           message: "No tag is used"
           description: "lorem ipsum tar"
           reference_url:
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
     MAINTAINER:
       paramSyntaxRegex: /.+/
@@ -78,7 +78,7 @@
       message: "Maintainer is not defined"
       description: "The MAINTAINER line is useful for identifying the author in the form of MAINTAINER Joe Smith <joe.smith@example.com>"
       reference_url:
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#maintainer"
     -
       instruction: "EXPOSE"
@@ -87,7 +87,7 @@
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
       reference_url:
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
     -
       instruction: "ENTRYPOINT"
@@ -96,7 +96,7 @@
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
       reference_url:
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
     -
       instruction: "CMD"
@@ -105,7 +105,7 @@
       message: "There is no 'CMD' instruction"
       description: "None"
       reference_url:
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
     -
       instruction: "USER"
@@ -114,5 +114,5 @@
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
       reference_url:
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#user"

--- a/test/data/rules/loader_test_combine_1.yaml
+++ b/test/data/rules/loader_test_combine_1.yaml
@@ -13,7 +13,7 @@
             message: "From rule 1"
             description: "FROM from profile 1"
             reference_url:
-              - "https://docs.docker.com/reference/builder/"
+              - "https://docs.docker.com/engine/reference/builder/"
               - "#from"
       LABEL:
         paramSyntaxRegex: /file1/
@@ -24,7 +24,7 @@
                   level: "error"
                   required: 'recommended'
                   reference_url:
-                    - "https://docs.docker.com/reference/builder/"
+                    - "https://docs.docker.com/engine/reference/builder/"
                     - "#from"
                Authoritative_Registry:
                  valueRegex: /.+/
@@ -32,7 +32,7 @@
                  level: "error"
                  required: true
                  reference_url:
-                   - "https://docs.docker.com/reference/builder/"
+                   - "https://docs.docker.com/engine/reference/builder/"
                    - "#from"
         rules:
           -
@@ -42,7 +42,7 @@
             message: "LABEL from profile 1"
             description: "LABEL from profile 1"
             reference_url:
-              - "https://docs.docker.com/reference/builder/"
+              - "https://docs.docker.com/engine/reference/builder/"
               - "#from"
   required_instructions:
       -
@@ -52,5 +52,5 @@
         message: "From combine 1"
         description: "From combine 1"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#env"

--- a/test/data/rules/loader_test_combine_2.yaml
+++ b/test/data/rules/loader_test_combine_2.yaml
@@ -13,7 +13,7 @@
                      message: "From rule 2"
                      description: "FROM from profile 2"
                      reference_url:
-                       - "https://docs.docker.com/reference/builder/"
+                       - "https://docs.docker.com/engine/reference/builder/"
                        - "#from"
           LABEL:
             paramSyntaxRegex: /file2/
@@ -24,7 +24,7 @@
                      level: "error"
                      required: true
                      reference_url:
-                       - "https://docs.docker.com/reference/builder/"
+                       - "https://docs.docker.com/engine/reference/builder/"
                        - "#from"
             rules:
               -
@@ -34,7 +34,7 @@
                 message: "LABEL from profile 2"
                 description: "FROM from profile 2"
                 reference_url:
-                  - "https://docs.docker.com/reference/builder/"
+                  - "https://docs.docker.com/engine/reference/builder/"
                   - "#from"
   required_instructions:
       -
@@ -44,5 +44,5 @@
         message: "From combine 2"
         description: "From combine 2"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#expose"

--- a/test/data/rules/loader_test_combine_main.expected.json
+++ b/test/data/rules/loader_test_combine_main.expected.json
@@ -8,7 +8,7 @@
     ]
   },
   "general": {
-    "ref_url_base": "https://docs.docker.com/reference/builder/",
+    "ref_url_base": "https://docs.docker.com/engine/reference/builder/",
     "valid_instructions": [
       "FROM",
       "MAINTAINER",
@@ -47,7 +47,7 @@
           "message": "From rule 2",
           "description": "FROM from profile 2",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         },
@@ -58,7 +58,7 @@
           "message": "From rule 1",
           "description": "FROM from profile 1",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         }
@@ -94,7 +94,7 @@
           "message": "LABEL from profile 2",
           "description": "FROM from profile 2",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         },
@@ -105,7 +105,7 @@
           "message": "LABEL from profile 1",
           "description": "LABEL from profile 1",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         }
@@ -117,9 +117,9 @@
           "level": "error",
           "required": "recommended",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from",
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         },
@@ -129,7 +129,7 @@
           "level": "error",
           "required": true,
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         }
@@ -179,7 +179,7 @@
       "message": "From combine 2",
       "description": "From combine 2",
       "reference_url": [
-        "https://docs.docker.com/reference/builder/",
+        "https://docs.docker.com/engine/reference/builder/",
         "#expose"
       ]
     },
@@ -190,7 +190,7 @@
       "message": "From combine 1",
       "description": "From combine 1",
       "reference_url": [
-        "https://docs.docker.com/reference/builder/",
+        "https://docs.docker.com/engine/reference/builder/",
         "#env"
       ]
     }

--- a/test/data/rules/loader_test_include_a.yaml
+++ b/test/data/rules/loader_test_include_a.yaml
@@ -29,5 +29,5 @@
       message: "From file A"
       description: "From profile A"
       reference_url: 
-        - "https://docs.docker.com/reference/builder/"
+        - "https://docs.docker.com/engine/reference/builder/"
         - "#maintainer"

--- a/test/data/rules/loader_test_include_b.yaml
+++ b/test/data/rules/loader_test_include_b.yaml
@@ -16,7 +16,7 @@
           message: "From profile B"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line."
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
         - 
           label: "no_tag"
@@ -25,5 +25,5 @@
           message: "From Profile B"
           description: "lorem ipsum tar"
           reference_url: 
-            - "https://docs.docker.com/reference/builder/"
+            - "https://docs.docker.com/engine/reference/builder/"
             - "#from"

--- a/test/data/rules/loader_test_include_chain.expected.json
+++ b/test/data/rules/loader_test_include_chain.expected.json
@@ -8,7 +8,7 @@
     ]
   },
   "general": {
-    "ref_url_base": "https://docs.docker.com/reference/builder/",
+    "ref_url_base": "https://docs.docker.com/engine/reference/builder/",
     "valid_instructions": [
       "FROM",
       "MAINTAINER",
@@ -47,7 +47,7 @@
           "message": "From profile B",
           "description": "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line.",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         },
@@ -58,7 +58,7 @@
           "message": "From Profile B",
           "description": "lorem ipsum tar",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         },
@@ -69,7 +69,7 @@
           "message": "From profile B",
           "description": "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line.",
           "reference_url": [
-            "https://docs.docker.com/reference/builder/",
+            "https://docs.docker.com/engine/reference/builder/",
             "#from"
           ]
         }
@@ -160,7 +160,7 @@
       "message": "From file A",
       "description": "From profile A",
       "reference_url": [
-        "https://docs.docker.com/reference/builder/",
+        "https://docs.docker.com/engine/reference/builder/",
         "#maintainer"
       ]
     },
@@ -171,7 +171,7 @@
       "message": "From C",
       "description": "From C",
       "reference_url": [
-        "https://docs.docker.com/reference/builder/",
+        "https://docs.docker.com/engine/reference/builder/",
         "#expose"
       ]
     }

--- a/test/data/rules/loader_test_include_chain.yaml
+++ b/test/data/rules/loader_test_include_chain.yaml
@@ -16,7 +16,7 @@
             message: "From profile B"
             description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line."
             reference_url:
-              - "https://docs.docker.com/reference/builder/"
+              - "https://docs.docker.com/engine/reference/builder/"
               - "#from"
   required_instructions:
       -
@@ -26,5 +26,5 @@
         message: "From C"
         description: "From C"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#expose"

--- a/test/data/rules/loader_test_include_cyclic.yaml
+++ b/test/data/rules/loader_test_include_cyclic.yaml
@@ -17,7 +17,7 @@
             message: "From profile B"
             description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line."
             reference_url:
-              - "https://docs.docker.com/reference/builder/"
+              - "https://docs.docker.com/engine/reference/builder/"
               - "#from"
   required_instructions:
       -
@@ -27,5 +27,5 @@
         message: "From C"
         description: "From C"
         reference_url:
-          - "https://docs.docker.com/reference/builder/"
+          - "https://docs.docker.com/engine/reference/builder/"
           - "#expose"


### PR DESCRIPTION
Recently docker changed their docs endpoint from `https://docs.docker.com/reference/builder/` to `https://docs.docker.com/engine/reference/builder/`