### PR TITLE
Deprecated MAINTAINER instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:centos7
 
-MAINTAINER Aaron Weitekamp <aweiteka@redhat.com> Lindani Phiri <lphiri@redhat.com>
+LABEL maintainer "Aaron Weitekamp <aweiteka@redhat.com> Lindani Phiri <lphiri@redhat.com>"
 
 RUN echo -e "[epel]\nname=epel\nenabled=1\nbaseurl=https://dl.fedoraproject.org/pub/epel/7/x86_64/\ngpgcheck=0" > /etc/yum.repos.d/epel.repo
 

--- a/config/default_rules.yaml
+++ b/config/default_rules.yaml
@@ -95,7 +95,16 @@
             - "#from"
     MAINTAINER: 
       paramSyntaxRegex: /.+/
-      rules: []
+      rules:
+        - 
+          label: "maintainer_deprecated"
+          regex: /.+/
+          level: "info"
+          message: "the MAINTAINER command is deprecated"
+          description: "MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0"
+          reference_url: 
+            - "https://github.com/docker/docker/blob/master/docs/deprecated.md"
+            - "#maintainer-in-dockerfile"
     RUN: 
       paramSyntaxRegex: /.+/
       rules: 

--- a/sample_rules/basic_rules.yaml
+++ b/sample_rules/basic_rules.yaml
@@ -104,7 +104,16 @@
             - "#entrypoint"
     MAINTAINER: 
       paramSyntaxRegex: /.+/
-      rules: []
+      rules:
+        -
+          label: "maintainer_deprecated"
+          regex: /.+/
+          level: "info"
+          message: "the MAINTAINER command is deprecated"
+          description: "MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0"
+          reference_url:
+            - "https://github.com/docker/docker/blob/master/docs/deprecated.md"
+            - "#maintainer-in-dockerfile"
     RUN: 
       paramSyntaxRegex: /.+/
       rules: 

--- a/sample_rules/basic_rules_atomic.yaml
+++ b/sample_rules/basic_rules_atomic.yaml
@@ -104,7 +104,16 @@
             - "#entrypoint"
     MAINTAINER: 
       paramSyntaxRegex: /.+/
-      rules: []
+      rules:
+        -
+          label: "maintainer_deprecated"
+          regex: /.+/
+          level: "info"
+          message: "the MAINTAINER command is deprecated"
+          description: "MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0"
+          reference_url:
+            - "https://github.com/docker/docker/blob/master/docs/deprecated.md"
+            - "#maintainer-in-dockerfile"
     RUN: 
       paramSyntaxRegex: /.+/
       rules: 

--- a/sample_rules/modules.yaml
+++ b/sample_rules/modules.yaml
@@ -193,7 +193,16 @@
       rules: []
     MAINTAINER:
       paramSyntaxRegex: /.+/
-      rules: []
+      rules:
+        -
+          label: "maintainer_deprecated"
+          regex: /.+/
+          level: "info"
+          message: "the MAINTAINER command is deprecated"
+          description: "MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0"
+          reference_url:
+            - "https://github.com/docker/docker/blob/master/docs/deprecated.md"
+            - "#maintainer-in-dockerfile"
   required_instructions: 
     -
       instruction: "EXPOSE"
@@ -231,9 +240,3 @@
       reference_url:
         - "http://docs.projectatomic.io/container-best-practices/#"
         - "_recommended_labels_for_your_project"
-
-#             message: "MAINTAINER is deprecated, use LABEL instead"
-#             level: "info"
-#             required: true
-#             reference_url: 
-#               - "https://docs.docker.com/engine/reference/builder/#maintainer-deprecated"

--- a/test/data/dockerfiles/TestLabels
+++ b/test/data/dockerfiles/TestLabels
@@ -6,7 +6,7 @@
 
 # Pull base image.
 FROM dockerfile/ubuntu
-MAINTAINER ubuntu
+
 # Install Nginx.
 
 RUN \

--- a/test/data/rules/basic.yaml
+++ b/test/data/rules/basic.yaml
@@ -26,7 +26,16 @@
             - "#from"
     MAINTAINER:
       paramSyntaxRegex: /.+/
-      rules: []
+      rules:
+        -
+          label: "maintainer_deprecated"
+          regex: /.+/
+          level: "info"
+          message: "the MAINTAINER command is deprecated"
+          description: "MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0"
+          reference_url:
+            - "https://github.com/docker/docker/blob/master/docs/deprecated.md"
+            - "#maintainer-in-dockerfile"
     RUN:
       paramSyntaxRegex: /.+/
       rules:


### PR DESCRIPTION
the MAINTAINER instruction is deprecated as of Docker v1.13.0 according to https://github.com/docker/docker/blob/master/docs/deprecated.md#maintainer-in-dockerfile. More details can be found in the actual PR at https://github.com/docker/docker/pull/25466. 

I have also made the appropriate change in the Dockerfile for the MAINTAINER line in this repo. 

Since there is no cut off date for officially removing it in Docker, this is just a soft `info` message for users to change their Dockerfiles to use LABEL instead. 

For the most part I just kept the MAINTAINER check in the tests so we can tell that the MAINTAINER step is still being checked appropriately. Until Docker states that the command will be invalid, we should still let it be valid. 