### PR TITLE
Add "start-period" as a valid CMD option for Healthcheck

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -146,7 +146,7 @@ function parseHealthcheck(cmd) {
         if (cmdDirectiveIndex > 0) {
             // There are options specified, so let's verify they're valid.
             var cmdDirectiveOptions = words.slice(0, cmdDirectiveIndex),
-                validCmdOptions = ["interval", "retries", "timeout"];
+                validCmdOptions = ["interval", "retries", "timeout", "start-period"];
 
             for (var i = 0; i < cmdDirectiveOptions.length; i++) {
                 var match = /--(\w+)=(\d+)/.exec(cmdDirectiveOptions[i]);


### PR DESCRIPTION
Docker added a new option "start-period" for Healthcheck https://docs.docker.com/engine/reference/builder/#healthcheck