### PR TITLE
Fix for 'start-period' option in HEALTHCHECK

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -149,7 +149,7 @@ function parseHealthcheck(cmd) {
                 validCmdOptions = ["interval", "retries", "timeout", "start-period"];
 
             for (var i = 0; i < cmdDirectiveOptions.length; i++) {
-                var match = /--(\w+)=(\d+)/.exec(cmdDirectiveOptions[i]);
+                var match = /--([a-zA-Z0-9_-]+)=(\d+)/.exec(cmdDirectiveOptions[i]);
                 if (!match) {
                     cmd.error = '"' + cmdDirectiveOptions[i] + '" isn\'t a syntactically valid CMD option';
                     return false;


### PR DESCRIPTION
It needs to match minus in the name as well.