### PR TITLE
Catch yum update/upgrade but ignore other update/upgrade in RUN

### DIFF
--- a/sample_rules/basic_rules.yaml
+++ b/sample_rules/basic_rules.yaml
@@ -128,7 +128,7 @@
             - "_clear_packaging_caches_and_temporary_package_downloads"
         - 
           label: "yum_update_all"
-          regex: /yum(.+update all|.+upgrade|.+update)/
+          regex: /yum([ t]+update all|[ t]+upgrade|[ t]+update)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"

--- a/sample_rules/basic_rules_atomic.yaml
+++ b/sample_rules/basic_rules_atomic.yaml
@@ -128,7 +128,7 @@
             - "_clear_packaging_caches_and_temporary_package_downloads"
         - 
           label: "yum_update_all"
-          regex: /yum(.+update all|.+upgrade|.+update|\.config)/
+          regex: /yum([ t]+update all|[ t]+upgrade|[ t]+update|\.config)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"

--- a/sample_rules/default_rules.yaml
+++ b/sample_rules/default_rules.yaml
@@ -110,7 +110,7 @@
             - "_clear_packaging_caches_and_temporary_package_downloads"
         - 
           label: "yum_update_all"
-          regex: /yum(.+update all|.+upgrade|.+update)/
+          regex: /yum([ t]+update all|[ t]+upgrade|[ t]+update)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"

--- a/sample_rules/modules.yaml
+++ b/sample_rules/modules.yaml
@@ -131,7 +131,7 @@
             - "_clear_packaging_caches_and_temporary_package_downloads"
         - 
           label: "yum_update_all"
-          regex: /yum(.+update all|.+upgrade|.+update|\.config)/
+          regex: /yum([ t]+update all|[ t]+upgrade|[ t]+update|\.config)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"

--- a/sample_rules/osbs.yaml
+++ b/sample_rules/osbs.yaml
@@ -115,7 +115,7 @@
             - "_clear_packaging_caches_and_temporary_package_downloads"
         - 
           label: "yum_update_all"
-          regex: /yum(.+update all|.+upgrade|.+update|\.config)/
+          regex: /yum([ t]+update all|[ t]+upgrade|[ t]+update|\.config)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"


### PR DESCRIPTION
When `RUN` has the word `yum` and at some later point the same `RUN` also contains `update all`, `update`, or `upgrade`, the condition was being met.  However this can break some workflows.

For example, the following matches the condition pointlessly because of line 4.  No actual `yum upgrade` happens here but the current conditions make it appear that way.
```
1 RUN yum install -y python2 py-setuptools \
2    && yum clean all \
3    && easy_install pip \
4    && pip install --upgrade pip
```

Instead, we can match by spaces and/or tabs using `[ \t]+`.  This way `yum`, followed by any number of spaces or tabs, followed by `update all`, `update`, or `upgrade` would allow the above Dockerfile to pass but the below Dockerfile would fail correctly or as expected.

```
1 RUN yum   update \
2    && yum install -y python2 py-setuptools \
3    && yum clean all \
4    && easy_install pip \
5    && pip install --upgrade pip
```

The same change can probably be made to the other installer methods, such as `apt-get` etc.