### PR TITLE
Cosmetic fix for 106; 'no_tag' has default text

### DIFF
--- a/config/default_rules.yaml
+++ b/config/default_rules.yaml
@@ -72,58 +72,58 @@
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
 
-    FROM: 
+    FROM:
       paramSyntaxRegex: /^[\w./\-:]+(:[${}\w.]+)?(-[${}\w.]+)?( as \w+)?$/i
-      rules: 
-        - 
+      rules:
+        -
           label: "is_latest_tag"
           regex: /latest/
           level: "error"
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
-          reference_url: 
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "no_tag"
           regex: /^[:]/
           level: "error"
           message: "No tag is used"
-          description: "lorem ipsum tar"
-          reference_url: 
+          description: "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-    MAINTAINER: 
+    MAINTAINER:
       paramSyntaxRegex: /.+/
       rules:
-        - 
+        -
           label: "maintainer_deprecated"
           regex: /.+/
           level: "info"
           message: "the MAINTAINER command is deprecated"
           description: "MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0"
-          reference_url: 
+          reference_url:
             - "https://github.com/docker/cli/blob/master/docs/deprecated.md"
             - "#maintainer-in-dockerfile"
-    RUN: 
+    RUN:
       paramSyntaxRegex: /.+/
-      rules: 
-        - 
+      rules:
+        -
           label: "no_yum_clean_all"
           regex: /yum(?!.+clean all|.+\.repo|-config|\.conf)/
           level: "warn"
           message: "yum clean all is not used"
           description: "the yum cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
-        - 
+        -
           label: "yum_update_all"
           regex: /yum(.+update all|.+upgrade|.+update)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -132,7 +132,7 @@
           level: "warn"
           message: "dnf clean all is not used"
           description: "the dnf cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -141,7 +141,7 @@
           level: "warn"
           message: "rvm cleanup is not used"
           description: "the rvm cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -150,25 +150,25 @@
           level: "warn"
           message: "gem cleanup all is not used"
           description: "the gem cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "no_apt-get_clean"
           regex: /apt-get install(?!.+clean)/g
           level: "info"
           message: "apt-get clean is not used"
           description: "the apt-get cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "privileged_run_container"
           regex: /privileged/
           level: "warn"
           message: "a privileged run container is allowed access to host devices"
           description: "Does this run need to be privileged?"
-          reference_url: 
+          reference_url:
             - "http://docs.docker.com/engine/reference/run/#"
             - "runtime-privilege-and-linux-capabilities"
         -
@@ -177,8 +177,8 @@
           level: "warn"
           message: "installing SSH in a container is not recommended"
           description: "Do you really need SSH in this image?"
-          reference_url: "https://github.com/jpetazzo/nsenter"	
-        - 
+          reference_url: "https://github.com/jpetazzo/nsenter"
+        -
           label: "no_ampersand_usage"
           regex: / ; /
           level: "info"
@@ -187,15 +187,15 @@
           reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "#_using_semi_colons_vs_double_ampersands"
-    EXPOSE: 
+    EXPOSE:
       paramSyntaxRegex: /^[\d-\s\w/\\]+$/
       rules: []
-    ENV: 
+    ENV:
       paramSyntaxRegex: /^[\w-$/\\=\"[\]{}@:,'`\t. ]+$/
       rules: []
-    ADD: 
+    ADD:
       paramSyntaxRegex: /^~?([\w-.~:/?#\[\]\\\/*@!$&'()*+,;=.{}"]+[\s]*)+$/
-    COPY: 
+    COPY:
       paramSyntaxRegex: /.+/
       rules: []
     ENTRYPOINT:
@@ -204,31 +204,31 @@
     VOLUME:
       paramSyntaxRegex: /.+/
       rules: []
-    USER: 
+    USER:
       paramSyntaxRegex: /^[a-z0-9_][a-z0-9_-]{0,40}$/
       rules: []
-    WORKDIR: 
+    WORKDIR:
       paramSyntaxRegex: /^~?[\w\d-\/.{}$\/:]+[\s]*$/
       rules: []
-    ONBUILD: 
+    ONBUILD:
       paramSyntaxRegex: /.+/
       rules: []
-  required_instructions: 
-    - 
+  required_instructions:
+    -
       instruction: "EXPOSE"
       count: 1
       level: "info"
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
-    - 
+    -
       instruction: "CMD"
       count: 1
       level: "info"
       message: "There is no 'CMD' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"

--- a/sample_rules/basic_rules_atomic.yaml
+++ b/sample_rules/basic_rules_atomic.yaml
@@ -72,28 +72,28 @@
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
 
-    FROM: 
+    FROM:
       paramSyntaxRegex: /^[\w./\-:]+(:[\w.]+)?(-[\w]+)?( as \w+)?$/i
-      rules: 
-        - 
+      rules:
+        -
           label: "is_latest_tag"
           regex: /latest/
           level: "error"
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
-          reference_url: 
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "no_tag"
           regex: /^[:]/
           level: "error"
           message: "No tag is used"
-          description: "lorem ipsum tar"
-          reference_url: 
+          description: "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "specified_registry"
           regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
           level: "warn"
@@ -102,7 +102,7 @@
           reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#entrypoint"
-    MAINTAINER: 
+    MAINTAINER:
       paramSyntaxRegex: /.+/
       rules:
         -
@@ -114,25 +114,25 @@
           reference_url:
             - "https://github.com/docker/cli/blob/master/docs/deprecated.md"
             - "#maintainer-in-dockerfile"
-    RUN: 
+    RUN:
       paramSyntaxRegex: /.+/
-      rules: 
-        - 
+      rules:
+        -
           label: "no_yum_clean_all"
           regex: /yum(?!.+clean all|.+\.repo|-config|\.conf)/g
           level: "warn"
           message: "yum clean all is not used"
           description: "the yum cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
-        - 
+        -
           label: "yum_update_all"
           regex: /yum(.+update all|.+upgrade|.+update|\.config)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -141,7 +141,7 @@
           level: "warn"
           message: "dnf clean all is not used"
           description: "the dnf cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -150,7 +150,7 @@
           level: "warn"
           message: "rvm cleanup is not used"
           description: "the rvm cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -159,25 +159,25 @@
           level: "warn"
           message: "gem cleanup all is not used"
           description: "the gem cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "no_apt-get_clean"
           regex: /apt-get install(?!.+clean)/g
           level: "warn"
           message: "apt-get clean is not used"
           description: "the apt-get cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "privileged_run_container"
           regex: /privileged/
           level: "warn"
           message: "a privileged run container is allowed access to host devices"
           description: "Does this run need to be privileged?"
-          reference_url: 
+          reference_url:
             - "http://docs.docker.com/engine/reference/run/#"
             - "runtime-privilege-and-linux-capabilities"
         -
@@ -186,8 +186,8 @@
           level: "warn"
           message: "installing SSH in a container is not recommended"
           description: "Do you really need SSH in this image?"
-          reference_url: "https://github.com/jpetazzo/nsenter"	
-        - 
+          reference_url: "https://github.com/jpetazzo/nsenter"
+        -
           label: "no_ampersand_usage"
           regex: / ; /
           level: "warn"
@@ -196,76 +196,76 @@
           reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "#_using_semi_colons_vs_double_ampersands"
-    EXPOSE: 
+    EXPOSE:
       paramSyntaxRegex: /^[\d-\s\w/\\]+$/
       rules: []
-    ENV: 
+    ENV:
       paramSyntaxRegex: /^[a-zA-Z_]+[a-zA-Z0-9_]* .+$/
       rules: []
-    ADD: 
+    ADD:
       paramSyntaxRegex: /^~?([\w-.~:/?#\[\]\\\/*@!$&'()*+,;=.{}"]+[\s]*)+$/
-    COPY: 
+    COPY:
       paramSyntaxRegex: /.+/
       rules: []
-    ENTRYPOINT: 
+    ENTRYPOINT:
       paramSyntaxRegex: /.+/
       rules: []
     VOLUME:
       paramSyntaxRegex: /.+/
       rules: []
-    USER: 
+    USER:
       paramSyntaxRegex: /^[a-z0-9_][a-z0-9_]{0,40}$/
       rules: []
-    WORKDIR: 
+    WORKDIR:
       paramSyntaxRegex: /^~?[\w\d-\/.{}$\/:]+[\s]*$/
       rules: []
-    ONBUILD: 
+    ONBUILD:
       paramSyntaxRegex: /.+/
       rules: []
-  required_instructions: 
-    - 
+  required_instructions:
+    -
       instruction: "MAINTAINER"
       count: 1
       level: "error"
       message: "Maintainer is not defined"
       description: "The MAINTAINER line is useful for identifying the author in the form of MAINTAINER Joe Smith <joe.smith@example.com>"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#maintainer"
-    - 
+    -
       instruction: "EXPOSE"
       count: 1
       level: "info"
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
-    - 
+    -
       instruction: "ENTRYPOINT"
       count: 1
       level: "info"
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
-    - 
+    -
       instruction: "CMD"
       count: 1
       level: "info"
       message: "There is no 'CMD' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
-    - 
+    -
       instruction: "USER"
       count: 1
       level: "warn"
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#user"
     -

--- a/sample_rules/default_rules.yaml
+++ b/sample_rules/default_rules.yaml
@@ -72,49 +72,49 @@
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
 
-    FROM: 
+    FROM:
       paramSyntaxRegex: /^[\w./\-:]+(:[${}\w.]+)?(-[${}\w.]+)?( as \w+)?$/i
-      rules: 
-        - 
+      rules:
+        -
           label: "is_latest_tag"
           regex: /latest/
           level: "error"
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
-          reference_url: 
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "no_tag"
           regex: /^[:]/
           level: "error"
           message: "No tag is used"
-          description: "lorem ipsum tar"
-          reference_url: 
+          description: "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-    MAINTAINER: 
+    MAINTAINER:
       paramSyntaxRegex: /.+/
       rules: []
-    RUN: 
+    RUN:
       paramSyntaxRegex: /.+/
-      rules: 
-        - 
+      rules:
+        -
           label: "no_yum_clean_all"
           regex: /yum(?!.+clean all|.+\.repo|-config|\.conf)/
           level: "warn"
           message: "yum clean all is not used"
           description: "the yum cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
-        - 
+        -
           label: "yum_update_all"
           regex: /yum(.+update all|.+upgrade|.+update)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -123,7 +123,7 @@
           level: "warn"
           message: "dnf clean all is not used"
           description: "the dnf cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -132,7 +132,7 @@
           level: "warn"
           message: "rvm cleanup is not used"
           description: "the rvm cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -141,25 +141,25 @@
           level: "warn"
           message: "gem cleanup all is not used"
           description: "the gem cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "no_apt-get_clean"
           regex: /apt-get install(?!.+clean)/g
           level: "info"
           message: "apt-get clean is not used"
           description: "the apt-get cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "privileged_run_container"
           regex: /privileged/
           level: "warn"
           message: "a privileged run container is allowed access to host devices"
           description: "Does this run need to be privileged?"
-          reference_url: 
+          reference_url:
             - "http://docs.docker.com/engine/reference/run/#"
             - "runtime-privilege-and-linux-capabilities"
         -
@@ -168,8 +168,8 @@
           level: "warn"
           message: "installing SSH in a container is not recommended"
           description: "Do you really need SSH in this image?"
-          reference_url: "https://github.com/jpetazzo/nsenter"	
-        - 
+          reference_url: "https://github.com/jpetazzo/nsenter"
+        -
           label: "no_ampersand_usage"
           regex: / ; /
           level: "info"
@@ -178,15 +178,15 @@
           reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "#_using_semi_colons_vs_double_ampersands"
-    EXPOSE: 
+    EXPOSE:
       paramSyntaxRegex: /^[\d-\s\w/\\]+$/
       rules: []
-    ENV: 
+    ENV:
       paramSyntaxRegex: /^[\w-$/\\=\"[\]{}@:,'`\t. ]+$/
       rules: []
-    ADD: 
+    ADD:
       paramSyntaxRegex: /^~?([\w-.~:/?#\[\]\\\/*@!$&'()*+,;=.{}"]+[\s]*)+$/
-    COPY: 
+    COPY:
       paramSyntaxRegex: /.+/
       rules: []
     ENTRYPOINT:
@@ -195,31 +195,31 @@
     VOLUME:
       paramSyntaxRegex: /.+/
       rules: []
-    USER: 
+    USER:
       paramSyntaxRegex: /^[a-z0-9_][a-z0-9_-]{0,40}$/
       rules: []
-    WORKDIR: 
+    WORKDIR:
       paramSyntaxRegex: /^~?[\w\d-\/.{}$\/:]+[\s]*$/
       rules: []
-    ONBUILD: 
+    ONBUILD:
       paramSyntaxRegex: /.+/
       rules: []
-  required_instructions: 
-    - 
+  required_instructions:
+    -
       instruction: "EXPOSE"
       count: 1
       level: "info"
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
-    - 
+    -
       instruction: "CMD"
       count: 1
       level: "info"
       message: "There is no 'CMD' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"

--- a/sample_rules/openshift.yaml
+++ b/sample_rules/openshift.yaml
@@ -23,7 +23,7 @@
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
-               - "defining-image-metadata" 
+               - "defining-image-metadata"
            'io.openshift.wants':
              valueRegex: /([\w]+)./
              message: "Label 'io.openshift.wants' is missing or has invalid format"
@@ -31,7 +31,7 @@
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
-               - "defining-image-metadata" 
+               - "defining-image-metadata"
            'io.openshift.description':
              valueRegex: /([\w]+)./
              message: "Label 'io.openshift.description' is missing or has invalid format"
@@ -39,7 +39,7 @@
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
-               - "defining-image-metadata" 
+               - "defining-image-metadata"
            'io.openshift.expose-services':
              valueRegex: /([\w:-]+)./
              message: "Label 'io.openshift.expose-services' is missing or has invalid format"
@@ -47,7 +47,7 @@
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
-               - "defining-image-metadata" 
+               - "defining-image-metadata"
            'io.openshift.non-scalable':
              valueRegex: /([\w]+)./
              message: "Label 'io.openshift.non-scalable' is missing or has invalid format"
@@ -55,7 +55,7 @@
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
-               - "defining-image-metadata" 
+               - "defining-image-metadata"
            'io.openshift.min-memory':
              valueRegex: /([\w]+)./
              message: "Label 'io.openshift.min-memory' is missing or has invalid format"
@@ -63,7 +63,7 @@
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
-               - "defining-image-metadata" 
+               - "defining-image-metadata"
            'io.openshift.min-cpu':
              valueRegex: /([\w]+)./
              message: "Label 'io.openshift.min-cpu' is missing or has invalid format"
@@ -71,29 +71,29 @@
              required: true
              reference_url:
                - "http://docs.openshift.org/latest/creating_images/metadata.html#"
-               - "defining-image-metadata" 
-    FROM: 
+               - "defining-image-metadata"
+    FROM:
       paramSyntaxRegex: /^[\w./\-:]+(:[\w.]+)?(-[\w]+)?( as \w+)?$/i
-      rules: 
-        - 
+      rules:
+        -
           label: "is_latest_tag"
           regex: /latest/
           level: "error"
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
-          reference_url: 
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "no_tag"
           regex: /^[:]/
           level: "error"
           message: "No tag is used"
-          description: "lorem ipsum tar"
-          reference_url: 
+          description: "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "specified_registry"
           regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
           level: "warn"
@@ -102,25 +102,25 @@
           reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#entrypoint"
-    RUN: 
+    RUN:
       paramSyntaxRegex: /.+/
-      rules: 
-        - 
+      rules:
+        -
           label: "no_yum_clean_all"
           regex: /yum(?!.+clean all|.+\.repo|-config|\.conf)/
           level: "warn"
           message: "yum clean all is not used"
           description: "the yum cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
-        - 
+        -
           label: "yum_update_all"
           regex: /yum(.+update all|.+upgrade|.+update|\.conf)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -129,7 +129,7 @@
           level: "warn"
           message: "dnf clean all is not used"
           description: "the dnf cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -138,7 +138,7 @@
           level: "warn"
           message: "rvm cleanup is not used"
           description: "the rvm cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -147,25 +147,25 @@
           level: "warn"
           message: "gem cleanup all is not used"
           description: "the gem cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "no_apt-get_clean"
           regex: /apt-get install(?!.+clean)/g
           level: "warn"
           message: "apt-get clean is not used"
           description: "the apt-get cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "privileged_run_container"
           regex: /privileged/
           level: "warn"
           message: "a privileged run container is allowed access to host devices"
           description: "Does this run need to be privileged?"
-          reference_url: 
+          reference_url:
             - "http://docs.docker.com/engine/reference/run/#"
             - "runtime-privilege-and-linux-capabilities"
         -
@@ -174,8 +174,8 @@
           level: "warn"
           message: "installing SSH in a container is not recommended"
           description: "Do you really need SSH in this image?"
-          reference_url: "https://github.com/jpetazzo/nsenter"	
-        - 
+          reference_url: "https://github.com/jpetazzo/nsenter"
+        -
           label: "no_ampersand_usage"
           regex: / ; /
           level: "warn"
@@ -184,67 +184,67 @@
           reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "#_using_semi_colons_vs_double_ampersands"
-    EXPOSE: 
+    EXPOSE:
       paramSyntaxRegex: /^[\d-\s\w/\\]+$/
       rules: []
-    ENV: 
+    ENV:
       paramSyntaxRegex: /^[\w-$/\\=\"[\]{}@:,'`\t. ]+$/
       rules: []
-    ADD: 
+    ADD:
       paramSyntaxRegex: /^~?([\w-.~:/?#\[\]\\\/*@!$&'()*+,;=.{}"]+[\s]*)+$/
-    COPY: 
+    COPY:
       paramSyntaxRegex: /.+/
       rules: []
-    ENTRYPOINT: 
+    ENTRYPOINT:
       paramSyntaxRegex: /.+/
       rules: []
     VOLUME:
       paramSyntaxRegex: /.+/
       rules: []
-    USER: 
+    USER:
       paramSyntaxRegex: /^[a-z0-9_][a-z0-9_]{0,30}$/
       rules: []
-    WORKDIR: 
+    WORKDIR:
       paramSyntaxRegex: /^~?[A-z0-9\/_.-]+$/
       rules: []
-    ONBUILD: 
+    ONBUILD:
       paramSyntaxRegex: /.+/
       rules: []
-  required_instructions: 
-    - 
+  required_instructions:
+    -
       instruction: "EXPOSE"
       count: 1
       level: "info"
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
-    - 
+    -
       instruction: "ENTRYPOINT"
       count: 1
       level: "info"
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
-    - 
+    -
       instruction: "CMD"
       count: 1
       level: "info"
       message: "There is no 'CMD' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
-    - 
+    -
       instruction: "USER"
       count: 1
       level: "warn"
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#user"
     -

--- a/sample_rules/osbs.yaml
+++ b/sample_rules/osbs.yaml
@@ -16,7 +16,7 @@
        #
        defined_namevals:
            BZComponent:
-             valueRegex: /([\w.\/\\:-]+)/ 
+             valueRegex: /([\w.\/\\:-]+)/
              message: "Label 'BZComponent' is missing or has invalid format"
              level: "error"
              required: true
@@ -71,28 +71,28 @@
              reference_url:
                - "http://docs.projectatomic.io/container-best-practices/#"
                - "_recommended_labels_for_your_project"
-    FROM: 
+    FROM:
       paramSyntaxRegex: /^[\w./\-:]+(:[\w.]+)?(-[\w]+)?( as \w+)?$/i
-      rules: 
-        - 
+      rules:
+        -
           label: "is_latest_tag"
           regex: /latest/
           level: "error"
           message: "base image uses 'latest' tag"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
-          reference_url: 
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "no_tag"
           regex: /^[:]/
           level: "warn"
           message: "No tag is used"
-          description: "lorem ipsum tar"
-          reference_url: 
+          description: "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "specified_registry"
           regex: /[\w]+?\.[\w-]+(\:|\.)([\w.]+|(\d+)?)([/?:].*)?/
           level: "info"
@@ -101,25 +101,25 @@
           reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#entrypoint"
-    RUN: 
+    RUN:
       paramSyntaxRegex: /.+/
-      rules: 
-        - 
+      rules:
+        -
           label: "no_yum_clean_all"
           regex: /yum(?!.+clean all|.+\.repo|-config|\.conf)/g
           level: "warn"
           message: "yum clean all is not used"
           description: "the yum cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
-        - 
+        -
           label: "yum_update_all"
           regex: /yum(.+update all|.+upgrade|.+update|\.config)/
           level: "info"
           message: "updating the entire base image may add unnecessary size to the container"
           description: "update the entire base image may add unnecessary size to the container"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -128,7 +128,7 @@
           level: "warn"
           message: "dnf clean all is not used"
           description: "the dnf cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -137,7 +137,7 @@
           level: "warn"
           message: "rvm cleanup is not used"
           description: "the rvm cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
         -
@@ -146,25 +146,25 @@
           level: "warn"
           message: "gem cleanup all is not used"
           description: "the gem cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "no_apt-get_clean"
           regex: /apt-get install(?!.+clean)/g
           level: "warn"
           message: "apt-get clean is not used"
           description: "the apt-get cache will remain in this layer making the layer unnecessarily large"
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
-            - "_clear_packaging_caches_and_temporary_package_downloads" 
+            - "_clear_packaging_caches_and_temporary_package_downloads"
         -
           label: "privileged_run_container"
           regex: /privileged/
           level: "warn"
           message: "a privileged run container is allowed access to host devices"
           description: "Does this run need to be privileged?"
-          reference_url: 
+          reference_url:
             - "http://docs.docker.com/engine/reference/run/#"
             - "runtime-privilege-and-linux-capabilities"
         -
@@ -173,8 +173,8 @@
           level: "warn"
           message: "installing SSH in a container is not recommended"
           description: "Do you really need SSH in this image?"
-          reference_url: "https://github.com/jpetazzo/nsenter"	
-        - 
+          reference_url: "https://github.com/jpetazzo/nsenter"
+        -
           label: "no_ampersand_usage"
           regex: / ; /
           level: "warn"
@@ -183,76 +183,76 @@
           reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "#_using_semi_colons_vs_double_ampersands"
-        - 
+        -
           label: "no_epel"
           regex: /epel/
           level: "warn"
           message: "Using epel is not recommended for the osbs profile."
           description: "Using epel RPMS is not recommended for the osbs profile."
-          reference_url: 
+          reference_url:
             - "http://docs.projectatomic.io/container-best-practices/#"
             - "_clear_packaging_caches_and_temporary_package_downloads"
-    EXPOSE: 
+    EXPOSE:
       paramSyntaxRegex: /^[\d-\s\w/\\]+$/
       rules: []
-    ENV: 
+    ENV:
       paramSyntaxRegex: /^[\w-$/\\=\"[\]{}@:,'`\t. ]+$/
       rules: []
-    ADD: 
+    ADD:
       paramSyntaxRegex: /^~?([\w-.~:/?#\[\]\\\/*@!$&'()*+,;=.{}"]+[\s]*)+$/
-    COPY: 
+    COPY:
       paramSyntaxRegex: /.+/
       rules: []
-    ENTRYPOINT: 
+    ENTRYPOINT:
       paramSyntaxRegex: /.+/
       rules: []
     VOLUME:
       paramSyntaxRegex: /.+/
       rules: []
-    USER: 
+    USER:
       paramSyntaxRegex: /^[a-z0-9_][a-z0-9_]{0,30}$/
       rules: []
-    WORKDIR: 
+    WORKDIR:
       paramSyntaxRegex: /^~?[\w\d-\/.{}$\/:]+[\s]*$/
       rules: []
-    ONBUILD: 
+    ONBUILD:
       paramSyntaxRegex: /.+/
       rules: []
-  required_instructions: 
-    - 
+  required_instructions:
+    -
       instruction: "EXPOSE"
       count: 1
       level: "info"
       message: "There is no 'EXPOSE' instruction"
       description: "Without exposed ports how will the service of the container be accessed?"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#expose"
-    - 
+    -
       instruction: "ENTRYPOINT"
       count: 1
       level: "info"
       message: "There is no 'ENTRYPOINT' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#entrypoint"
-    - 
+    -
       instruction: "CMD"
       count: 1
       level: "info"
       message: "There is no 'CMD' instruction"
       description: "None"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#cmd"
-    - 
+    -
       instruction: "USER"
       count: 1
       level: "warn"
       message: "No 'USER' instruction"
       description: "The process(es) within the container may run as root and RUN instructions my be run as root"
-      reference_url: 
+      reference_url:
         - "https://docs.docker.com/engine/reference/builder/"
         - "#user"
     -

--- a/test/data/rules/basic.yaml
+++ b/test/data/rules/basic.yaml
@@ -20,7 +20,7 @@
           regex: /^[:]/
           level: "warn"
           message: "No tag is used"
-          description: "lorem ipsum tar"
+          description: "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
           reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"

--- a/test/data/rules/loader_test_include_b.yaml
+++ b/test/data/rules/loader_test_include_b.yaml
@@ -5,25 +5,25 @@
     includes:
         - loader_test_include_a.yaml
 
-  line_rules: 
+  line_rules:
     FROM:
       paramSyntaxRegex: /fileb/
-      rules: 
-        - 
+      rules:
+        -
           label: "From Profile B"
           regex: /latest/
           level: "info"
           message: "From profile B"
           description: "using the 'latest' tag may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line."
-          reference_url: 
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"
-        - 
+        -
           label: "no_tag"
           regex: /^[:]/
           level: "warn"
           message: "From Profile B"
-          description: "lorem ipsum tar"
-          reference_url: 
+          description: "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release."
+          reference_url:
             - "https://docs.docker.com/engine/reference/builder/"
             - "#from"

--- a/test/data/rules/loader_test_include_chain.expected.json
+++ b/test/data/rules/loader_test_include_chain.expected.json
@@ -56,7 +56,7 @@
           "regex": "/^[:]/",
           "level": "warn",
           "message": "From Profile B",
-          "description": "lorem ipsum tar",
+          "description": "No tag as been set, this may cause unpredictable builds. It is recommended that a specific tag is used in the FROM line or *-released which is the latest supported release.",
           "reference_url": [
             "https://docs.docker.com/engine/reference/builder/",
             "#from"


### PR DESCRIPTION
Replacing the default "lorem ipsum tar" with more explanatory text.