### PR TITLE
Adding support for JUnit XML format as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ To display results as JSON use the `-j` option:
 dockerfile_lint  -j -f /path/to/dockerfile  [ -r /path/to/rule/file]
 ```
 
+To display results as JUnit XML file use the `-u` option:
+```
+dockerfile_lint  -u -f /path/to/dockerfile  [ -r /path/to/rule/file]
+```
+
 Command Help:
 ```
 dockerfile_lint  -h

--- a/bin/dockerfile_lint
+++ b/bin/dockerfile_lint
@@ -13,6 +13,7 @@ var fs = require('fs'),
     ImageLinter = require('../lib/image-linter'),
     printResults = require('./functions').printResults,
     printJsonResults = require('./functions').printJsonResults,
+    printJunitResults = require('./functions').printJunitResults,
     getContent = require('./functions').getContent,
     rulefileLocation = null,
     rulefile = null,
@@ -26,7 +27,9 @@ function collectArgs(arg, args) {
   return args;
 }
 
-commandline.option('-j, --json', 'Show results in JSON format')
+commandline
+    .option('-j, --json', 'Show results in JSON format')
+    .option('-u, --junit', 'Show results in JUnit XML format')
     .option('-r, --rulefile [rulefile] (optional)', 'Rule file', rulefile)
     .option('-f, --dockerfile [dockerfile] (optional)', 'File to lint. Accepts a local file or an http(s) URL. If not present attempts to lint dockerfile in current directory', collectArgs, [])
     .option('-p, --permissive', 'Run in permissive mode (return 1 only on error but not on warning)')
@@ -54,6 +57,12 @@ if (rulefileLocation !== null) {
     }
 }
 
+// Make sure both JSON and JUnit output options aren't set since they are mutually exclusive
+if (commandline.json && commandline.junit) {
+    console.error('ERROR: result format options ("--json and --junit") cannot be used together, please choose one only');
+    process.exit(1);
+}
+
 if (commandline.permissive) {
     strictMode = false;
 }
@@ -71,7 +80,7 @@ if (commandline.dockerfile.length === 0 && !lintImage) {
 
 function lintDockerFiles() {
     var lintPromises = _.map(commandline.dockerfile, function (dockerfileLocation) {
-        if (!commandline.json) {
+        if (!commandline.json && !commandline.junit) {
             console.info('\n# Analyzing ' + dockerfileLocation + '\n');
         }
         return lintDockerFile(dockerfileLocation);
@@ -79,6 +88,8 @@ function lintDockerFiles() {
     Promise.all(lintPromises).then(function (results) {
         if (commandline.json) {
             printJsonResults(results.length === 1 ? results[0] : results);
+        } else if (commandline.junit) {
+            printJunitResults(results.length === 1 ? results[0] : results);
         } else {
             results.forEach(printResults);
         }
@@ -130,6 +141,8 @@ function lintImageFromInspect() {
         var results = linter.validate(inspectOutPut);
         if (commandline.json) {
             printJsonResults(results);
+        } else if (commandline.junit) {
+            printJunitResults(results);
         } else {
             printResults(results);
         }

--- a/bin/functions.js
+++ b/bin/functions.js
@@ -2,6 +2,7 @@
  * Created by lphiri on 3/29/16.
  */
 'use strict';
+var builder = require('junit-report-builder');
 var util = require('util');
 
 function getRefUrl(url) {
@@ -87,6 +88,48 @@ function printJsonResults(results) {
     console.log(json);
 }
 
+function makeJunitTestCase(suite, type, entry) {
+    var ref_url = getRefUrl(entry.reference_url);
+    var message = entry.message ? entry.message : " ";
+    var description = entry.description ? entry.description + " | " : "";
+    description = description + "Reference -> " + ref_url;
+
+    suite.testCase()
+        .className(type)
+        .name(message)
+        .failure(description);
+}
+
+function printJunitResults(results) {
+    // Create a test suite
+    var suite = builder.testSuite().name('dockerfile_lint');
+
+    // Get test results
+    var errors = results.error;
+    var warn = results.warn;
+    var info = results.info;
+
+    // Convert test results to JUnit test cases
+    if (errors && errors.data && errors.data.length > 0) {
+        errors.data.forEach(function (entry) {
+            makeJunitTestCase(suite, "ERROR", entry);
+        });
+    }
+    if (warn && warn.data && warn.data.length > 0) {
+        warn.data.forEach(function (entry) {
+            makeJunitTestCase(suite, "INFO", entry);
+        });
+    }
+    if (info && info.data && info.data.length > 0) {
+        info.data.forEach(function (entry) {
+            makeJunitTestCase(suite, "WARNING", entry);
+        });
+    }
+
+    console.log(builder.build());
+}
+
 module.exports.printResults = printResults;
 module.exports.printJsonResults = printJsonResults;
+module.exports.printJunitResults = printJunitResults;
 module.exports.getContent = getContent;

--- a/bin/functions.js
+++ b/bin/functions.js
@@ -89,10 +89,15 @@ function printJsonResults(results) {
 }
 
 function makeJunitTestCase(suite, type, entry) {
-    var ref_url = getRefUrl(entry.reference_url);
+    var lineContent = "";
+    if (entry.lineContent) {
+        var line = entry.line ? ("Line " + entry.line + ":") : "Line 0:";
+        lineContent = line + " -> " + entry.lineContent + ". ";
+    }
     var message = entry.message ? entry.message : " ";
+    var ref_url = getRefUrl(entry.reference_url);
     var description = entry.description ? entry.description + " | " : "";
-    description = description + "Reference -> " + ref_url;
+    description = lineContent + message + ". " + description + "Reference -> " + ref_url;
 
     suite.testCase()
         .className(type)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,42 @@
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "bl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
+    },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "colors": {
       "version": "1.0.3",
@@ -48,13 +78,14 @@
       }
     },
     "concat-stream": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "~2.0.0",
-        "typedarray": "~0.0.5"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "core-util-is": {
@@ -74,9 +105,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -90,12 +121,17 @@
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
+    "date-format": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.2.tgz",
+      "integrity": "sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE="
+    },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "diff": {
@@ -105,12 +141,12 @@
       "dev": true
     },
     "docker-modem": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.6.tgz",
-      "integrity": "sha512-kDwWa5QaiVMB8Orbb7nXdGdwEZHKfEm7iPwglXe1KorImMpmGNlhC7A5LG0p8rrCcz1J4kJhq/o63lFjDdj8rQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.9.tgz",
+      "integrity": "sha512-lVjqCSCIAUDZPAZIeyM125HXfNvOmYYInciphNrLrylUtKyW66meAjSPXWchKVzoIYZx69TPnAepVSSkeawoIw==",
       "requires": {
         "JSONStream": "1.3.2",
-        "debug": "^3.1.0",
+        "debug": "^3.2.6",
         "readable-stream": "~1.0.26-4",
         "split-ca": "^1.0.0"
       },
@@ -130,23 +166,28 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "dockerode": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.5.4.tgz",
-      "integrity": "sha512-esqrDATdckYhkOFn4BSOrqnkj3jgBkHT07uEqTRwK6na4/Rg60vjXWRopv2BbRpvFruMmKvOSNVY4MbmVBUnWw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.5.8.tgz",
+      "integrity": "sha512-+7iOUYBeDTScmOmQqpUYQaE7F4vvIt6+gIZNHWhqAQEI887tiPFB9OvXI/HzQYqfUNvukMK+9myLW63oTJPZpw==",
       "requires": {
-        "concat-stream": "~1.5.1",
-        "docker-modem": "^1.0.0",
-        "tar-fs": "~1.12.0"
+        "concat-stream": "~1.6.2",
+        "docker-modem": "^1.0.8",
+        "tar-fs": "~1.16.3"
       }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -166,6 +207,17 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "fast-xml-parser": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz",
+      "integrity": "sha512-qudnQuyYBgnvzf5Lj/yxMcf4L9NcVWihXJg7CiU1L+oUCq8MUnFEfH2/nXR/W5uq+yvUN1h7z6s7vs2v1WkL1A==",
+      "dev": true
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "glob": {
       "version": "3.2.3",
@@ -196,9 +248,9 @@
       "dev": true
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -254,6 +306,24 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
+    "junit-report-builder": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-2.1.0.tgz",
+      "integrity": "sha512-Ioj5I4w18ZcHFaaisqCKdh1z+ipzN7sA2JB+h+WOlGcOMWm0FFN1dfxkgc2I4EXfhSP/mOfM3W43uFzEdz4sTw==",
+      "requires": {
+        "date-format": "0.0.2",
+        "lodash": "^4.17.15",
+        "make-dir": "^1.3.0",
+        "xmlbuilder": "^10.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+        }
+      }
+    },
     "lodash": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
@@ -264,6 +334,14 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "requires": {
+        "pify": "^3.0.0"
+      }
     },
     "minimatch": {
       "version": "0.2.14",
@@ -276,16 +354,16 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -319,6 +397,12 @@
             "ms": "0.6.2"
           }
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
         "mkdirp": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
@@ -337,9 +421,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "once": {
       "version": "1.4.0",
@@ -355,6 +439,11 @@
       "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
       "dev": true
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
     "pre-commit": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
@@ -367,9 +456,9 @@
       }
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -387,17 +476,23 @@
       }
     },
     "readable-stream": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "inherits": "~2.0.3",
         "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -425,7 +520,7 @@
     },
     "should-equal": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.0.1.tgz",
       "integrity": "sha1-VQZmU6nwMhHaaVov6naLGZVqnAs=",
       "dev": true
     },
@@ -461,28 +556,35 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "tar-fs": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.12.0.tgz",
-      "integrity": "sha1-pqgFU9ilTHPeHQrg553ncDVgXh0=",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "mkdirp": "^0.5.0",
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
         "pump": "^1.0.0",
         "tar-stream": "^1.1.2"
       }
     },
     "tar-stream": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "requires": {
         "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
         "end-of-stream": "^1.0.0",
-        "readable-stream": "^2.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
       }
     },
@@ -490,6 +592,11 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -528,10 +635,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="
+    },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -511,9 +511,9 @@
       }
     },
     "winston": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
-      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+      "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
       "requires": {
         "async": "~1.0.0",
         "colors": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dockerode": "^2.2.9",
     "js-yaml": "~3.13.1",
     "lodash": "^2.4.2",
-    "winston": "^2.1.1"
+    "winston": "^2.4.5"
   },
   "devDependencies": {
     "mocha": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "commander": "~2.9.0",
     "dockerode": "^2.2.9",
     "js-yaml": "~3.13.1",
+    "junit-report-builder": "^2.1.0",
     "lodash": "^2.4.2",
     "winston": "^2.4.5"
   },
   "devDependencies": {
+    "fast-xml-parser": "^3.17.4",
     "mocha": "~2.0.1",
     "pre-commit": "^1.1.2",
     "should": "~4.1.0"

--- a/test/integration/exec.spec.js
+++ b/test/integration/exec.spec.js
@@ -6,7 +6,7 @@ var should = require('should');
 var exec = require('child_process').exec,
     path = require('path')
 var binScript = path.join('bin', 'dockerfile_lint')
-
+var parser = require('fast-xml-parser');
 
 describe('The dockerfile_lint command', function () {
 
@@ -92,5 +92,28 @@ describe('The dockerfile_lint command', function () {
             done();
         });
     });
+
+    it('should exit with code 1 and error message when using both --json and --junit options ', function (done) {
+        var p = exec('node ' + binScript + ' --junit --json -f test/data/dockerfiles/TestLabels',
+            function (err, stdout, stderr) {
+                should(stderr).be.equal("ERROR: result format options (\"--json and --junit\") cannot be used together, please choose one only\n")
+            });
+        p.on('exit', function (code) {
+            code.should.eql(1);
+            done();
+        });
+    });
+
+    it('should output valid XML when in --junit mode', function (done) {
+        var p = exec('node ' + binScript + ' --junit -f test/data/dockerfiles/TestLabels -p -r test/data/rules/basic.yaml',
+            function (err, stdout, stderr) {
+                should(parser.validate(stdout)).be.ok;
+            });
+        p.on('exit', function (code) {
+            code.should.eql(0);
+            done();
+        });
+    });
+
 
 });


### PR DESCRIPTION
Adding support for JUnit XML format as output. This is needed because some CI/CD tools support this out of the box.

I also upgraded winston so "npm test" works again.