### PR TITLE
Fix Junit Warning/Info

### DIFF
--- a/bin/functions.js
+++ b/bin/functions.js
@@ -122,12 +122,12 @@ function printJunitResults(results) {
     }
     if (warn && warn.data && warn.data.length > 0) {
         warn.data.forEach(function (entry) {
-            makeJunitTestCase(suite, "INFO", entry);
+            makeJunitTestCase(suite, "WARNING", entry);
         });
     }
     if (info && info.data && info.data.length > 0) {
         info.data.forEach(function (entry) {
-            makeJunitTestCase(suite, "WARNING", entry);
+            makeJunitTestCase(suite, "INFO", entry);
         });
     }
 


### PR DESCRIPTION
Hi,

When you're using the JUnit output, INFOs are displayed as WARNINGs and the WARNINGs as INFOs.

Here an example.

The Dockerfile:

```
FROM node:12

LABEL Name='test'
LABEL Version='1.0'
```

The classical output:

```
# Analyzing Dockerfile


--------INFO---------

INFO: There is no 'EXPOSE' instruction. Without exposed ports how will the service of the container be accessed?. 
Reference -> https://docs.docker.com/engine/reference/builder/#expose


INFO: There is no 'CMD' instruction. None. 
Reference -> https://docs.docker.com/engine/reference/builder/#cmd
```

The Junit ouput:

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="dockerfile_lint" tests="2" failures="2" errors="0" skipped="0">
    <testcase classname="WARNING" name="There is no 'EXPOSE' instruction">
      <failure message="There is no 'EXPOSE' instruction. Without exposed ports how will the service of the container be accessed? | Reference -> https://docs.docker.com/engine/reference/builder/#expose"/>
    </testcase>
    <testcase classname="WARNING" name="There is no 'CMD' instruction">
      <failure message="There is no 'CMD' instruction. None | Reference -> https://docs.docker.com/engine/reference/builder/#cmd"/>
    </testcase>
  </testsuite>
</testsuites>
```

This PR fixes the problem.

Regards,
Julien